### PR TITLE
Improve operation summaries and add field descriptions

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -39,7 +39,7 @@ public isolated client class Client {
         self.clientEp = check new (serviceUrl, httpClientConfig);
     }
 
-    # Read a batch of products by internal ID, or unique property values
+    # Read products by ID or property
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
@@ -58,8 +58,9 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Read
+    # Retrieve a product by ID
     #
+    # + productId - The unique internal identifier of the product to retrieve.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -75,8 +76,9 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Archive
+    # Archive a product by ID
     #
+    # + productId - The unique internal identifier of the product to archive.
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [string productId](map<string|string[]> headers = {}) returns error? {
@@ -89,8 +91,9 @@ public isolated client class Client {
         return self.clientEp->delete(resourcePath, headers = httpHeaders);
     }
 
-    # Update
+    # Partially update a product
     #
+    # + productId - The unique internal identifier of the product to update.
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -142,7 +145,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Update a batch of products by internal ID, or unique property values
+    # Update a batch of products
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
@@ -159,7 +162,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # List
+    # Retrieve a page of products
     #
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
@@ -176,7 +179,7 @@ public isolated client class Client {
         return self.clientEp->get(resourcePath, httpHeaders);
     }
 
-    # Create
+    # Create a new product
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
@@ -193,7 +196,7 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
-    # Create or update a batch of products by unique property values
+    # Upsert a batch of products
     #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
@@ -210,6 +213,8 @@ public isolated client class Client {
         return self.clientEp->post(resourcePath, request, httpHeaders);
     }
 
+    # Search for products
+    #
     # + headers - Headers to be sent with the request 
     # + return - successful operation 
     resource isolated function post search(PublicObjectSearchRequest payload, map<string|string[]> headers = {}) returns CollectionResponseWithTotalSimplePublicObjectForwardPaging|error {

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -23,7 +23,7 @@ import ballerina/http;
 public isolated client class Client {
     final http:Client clientEp;
     final readonly & ApiKeysConfig? apiKeyConfig;
-    # Gets invoked to initialize the `connector`.
+    # Gets invoked to initialize the `connector`
     #
     # + config - The configurations to be used when initializing the `connector` 
     # + serviceUrl - URL of the target service 
@@ -60,7 +60,7 @@ public isolated client class Client {
 
     # Retrieve a product by ID
     #
-    # + productId - The unique internal identifier of the product to retrieve.
+    # + productId - The unique internal identifier of the product to retrieve
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 
@@ -78,7 +78,7 @@ public isolated client class Client {
 
     # Archive a product by ID
     #
-    # + productId - The unique internal identifier of the product to archive.
+    # + productId - The unique internal identifier of the product to archive
     # + headers - Headers to be sent with the request 
     # + return - No content 
     resource isolated function delete [string productId](map<string|string[]> headers = {}) returns error? {
@@ -93,7 +93,7 @@ public isolated client class Client {
 
     # Partially update a product
     #
-    # + productId - The unique internal identifier of the product to update.
+    # + productId - The unique internal identifier of the product to update
     # + headers - Headers to be sent with the request 
     # + queries - Queries to be sent with the request 
     # + return - successful operation 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,31 +19,31 @@
 
 import ballerina/http;
 
-# Standard error response structure returned by the API.
+# Standard error response structure returned by the API
 public type StandardError record {
-    # Optional sub-category providing additional error classification.
+    # Optional sub-category providing additional error classification
     record {} subCategory?;
-    # Contextual metadata map with string array values for the error.
+    # Contextual metadata map with string array values for the error
     record {|string[]...;|} context;
-    # Map of relevant links associated with the error response.
+    # Map of relevant links associated with the error response
     record {|string...;|} links;
-    # Unique identifier for the error instance.
+    # Unique identifier for the error instance
     string id?;
-    # High-level category classifying the type of error.
+    # High-level category classifying the type of error
     string category;
-    # Human-readable message describing the error.
+    # Human-readable message describing the error
     string message;
-    # List of detailed error entries associated with this error.
+    # List of detailed error entries associated with this error
     ErrorDetail[] errors;
-    # HTTP status code or status label for the error response.
+    # HTTP status code or status label for the error response
     string status;
 };
 
-# Paginated collection of associated object IDs.
+# Paginated collection of associated object IDs
 public type CollectionResponseAssociatedId record {
-    # Pagination metadata containing cursors for navigating to next and previous pages.
+    # Pagination metadata containing cursors for navigating to next and previous pages
     Paging paging?;
-    # Array of associated IDs returned in the response.
+    # Array of associated IDs returned in the response
     AssociatedId[] results;
 };
 
@@ -53,33 +53,33 @@ public type PatchProductIdUpdateQueries record {
     string idProperty?;
 };
 
-# Defines the target object and association types for a relationship.
+# Defines the target object and association types for a relationship
 public type PublicAssociationsForObject record {
-    # List of association type specifications for the relationship.
+    # List of association type specifications for the relationship
     AssociationSpec[] types;
-    # Represents a public object identifier containing a unique ID string.
+    # Represents a public object identifier containing a unique ID string
     PublicObjectId to;
 };
 
-# Batch operation response containing product objects and status.
+# Batch operation response containing product objects and status
 public type BatchResponseSimplePublicObject record {
-    # Timestamp when the batch operation completed.
+    # Timestamp when the batch operation completed
     string completedAt;
-    # Timestamp when the batch operation was requested.
+    # Timestamp when the batch operation was requested
     string requestedAt?;
-    # Timestamp when the batch operation started processing.
+    # Timestamp when the batch operation started processing
     string startedAt;
-    # Map of relevant links related to the batch response.
+    # Map of relevant links related to the batch response
     record {|string...;|} links?;
-    # List of product objects returned in the batch response.
+    # List of product objects returned in the batch response
     SimplePublicObject[] results;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# A logical grouping of filters applied together when searching products.
+# A logical grouping of filters applied together when searching products
 public type FilterGroup record {
-    # List of filter conditions within this filter group.
+    # List of filter conditions within this filter group
     Filter[] filters;
 };
 
@@ -99,7 +99,7 @@ public type GetGetPageQueries record {
     string[] properties?;
 };
 
-# Detailed information about a specific error encountered during a request.
+# Detailed information about a specific error encountered during a request
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -113,85 +113,85 @@ public type ErrorDetail record {
     string message;
 };
 
-# Pagination object providing a cursor for retrieving the next page of results.
+# Pagination object providing a cursor for retrieving the next page of results
 public type ForwardPaging record {
-    # Pagination cursor details for retrieving the next page of results.
+    # Pagination cursor details for retrieving the next page of results
     NextPage next?;
 };
 
-# A minimal object representation containing only a unique identifier.
+# A minimal object representation containing only a unique identifier
 public type SimplePublicObjectId record {
-    # The unique identifier of the product object.
+    # The unique identifier of the product object
     string id;
 };
 
-# Batch upsert response containing results, status, timing metadata, and any errors encountered.
+# Batch upsert response containing results, status, timing metadata, and any errors encountered
 public type BatchResponseSimplePublicUpsertObjectWithErrors record {
-    # Timestamp when the batch operation completed.
+    # Timestamp when the batch operation completed
     string completedAt;
-    # Total number of errors encountered during the batch operation.
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
-    # Timestamp when the batch operation was requested.
+    # Timestamp when the batch operation was requested
     string requestedAt?;
-    # Timestamp when the batch operation began processing.
+    # Timestamp when the batch operation began processing
     string startedAt;
-    # Map of relevant hyperlinks associated with the batch response.
+    # Map of relevant hyperlinks associated with the batch response
     record {|string...;|} links?;
-    # List of upserted product objects returned in the batch response.
+    # List of upserted product objects returned in the batch response
     SimplePublicUpsertObject[] results;
-    # List of errors encountered for individual records in the batch.
+    # List of errors encountered for individual records in the batch
     StandardError[] errors?;
-    # Current processing status of the batch upsert operation.
+    # Current processing status of the batch upsert operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Input payload for batch reading products by ID, specifying properties to retrieve.
+# Input payload for batch reading products by ID, specifying properties to retrieve
 public type BatchReadInputSimplePublicObjectId record {
-    # List of properties for which to return historical values.
+    # List of properties for which to return historical values
     string[] propertiesWithHistory;
     # The name of a property whose values are unique for this object
     string idProperty?;
-    # List of object IDs to retrieve in the batch request.
+    # List of object IDs to retrieve in the batch request
     SimplePublicObjectId[] inputs;
-    # List of property names to include in the response.
+    # List of property names to include in the response
     string[] properties;
 };
 
-# Response object containing the status, timing, and results of a batch upsert operation on products.
+# Response object containing the status, timing, and results of a batch upsert operation on products
 public type BatchResponseSimplePublicUpsertObject record {
-    # Timestamp when the batch operation completed.
+    # Timestamp when the batch operation completed
     string completedAt;
-    # Timestamp when the batch operation was requested.
+    # Timestamp when the batch operation was requested
     string requestedAt?;
-    # Timestamp when the batch operation began processing.
+    # Timestamp when the batch operation began processing
     string startedAt;
-    # Map of related resource links associated with the batch response.
+    # Map of related resource links associated with the batch response
     record {|string...;|} links?;
-    # Collection of upserted product objects returned by the batch operation.
+    # Collection of upserted product objects returned by the batch operation
     SimplePublicUpsertObject[] results;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# A property value paired with its source information and the timestamp of the last update.
+# A property value paired with its source information and the timestamp of the last update
 public type ValueWithTimestamp record {
-    # Identifier of the source that set this property value.
+    # Identifier of the source that set this property value
     string sourceId?;
-    # Type of source that last updated this property value.
+    # Type of source that last updated this property value
     string sourceType;
-    # Human-readable label describing the source of the value.
+    # Human-readable label describing the source of the value
     string sourceLabel?;
-    # ID of the user who last updated this property value.
+    # ID of the user who last updated this property value
     int:Signed32 updatedByUserId?;
-    # The property value associated with the given timestamp.
+    # The property value associated with the given timestamp
     string value;
-    # Timestamp when this property value was last updated.
+    # Timestamp when this property value was last updated
     string timestamp;
 };
 
-# Input schema for a batch operation containing a list of product object IDs.
+# Input schema for a batch operation containing a list of product object IDs
 public type BatchInputSimplePublicObjectId record {
-    # List of product object IDs to process in the batch operation.
+    # List of product object IDs to process in the batch operation
     SimplePublicObjectId[] inputs;
 };
 
@@ -202,44 +202,44 @@ public type OAuth2RefreshTokenGrantConfig record {|
     string refreshUrl = "https://api.hubapi.com/oauth/v1/token";
 |};
 
-# Input schema for a batch upsert operation containing a list of product objects to create or update.
+# Input schema for a batch upsert operation containing a list of product objects to create or update
 public type BatchInputSimplePublicObjectBatchInputUpsert record {
-    # List of product objects to create or update in the batch upsert.
+    # List of product objects to create or update in the batch upsert
     SimplePublicObjectBatchInputUpsert[] inputs;
 };
 
-# Paginated collection of product objects with a total count and forward paging cursor.
+# Paginated collection of product objects with a total count and forward paging cursor
 public type CollectionResponseWithTotalSimplePublicObjectForwardPaging record {
-    # Total number of results matching the request.
+    # Total number of results matching the request
     int:Signed32 total;
-    # Pagination object providing a cursor for retrieving the next page of results.
+    # Pagination object providing a cursor for retrieving the next page of results
     ForwardPaging paging?;
-    # Array of product objects returned in the current page.
+    # Array of product objects returned in the current page
     SimplePublicObject[] results;
 };
 
-# Represents a product record with its properties, timestamps, and archival status.
+# Represents a product record with its properties, timestamps, and archival status
 public type SimplePublicObject record {
-    # Timestamp when the product record was created.
+    # Timestamp when the product record was created
     string createdAt;
-    # Indicates whether the product record is archived.
+    # Indicates whether the product record is archived
     boolean archived?;
-    # Timestamp when the product record was archived.
+    # Timestamp when the product record was archived
     string archivedAt?;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # Unique identifier of the product record.
+    # Unique identifier of the product record
     string id;
-    # Map of property names to their current values for the product.
+    # Map of property names to their current values for the product
     record {|string?...;|} properties;
-    # Timestamp when the product record was last updated.
+    # Timestamp when the product record was last updated
     string updatedAt;
 };
 
-# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
+# Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
-    # Provides Auth configurations needed when communicating with a remote HTTP endpoint.
+    # Provides Auth configurations needed when communicating with a remote HTTP endpoint
     http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig|ApiKeysConfig auth;
     # The HTTP version understood by the client
     http:HttpVersion httpVersion = http:HTTP_2_0;
@@ -276,49 +276,49 @@ public type ConnectionConfig record {|
     # Enables the inbound payload validation functionality which provided by the constraint package. Enabled by default
     boolean validation = true;
     # Enables relaxed data binding on the client side. When enabled, `nil` values are treated as optional, 
-    # and absent fields are handled as `nilable` types. Enabled by default.
+    # and absent fields are handled as `nilable` types. Enabled by default
     boolean laxDataBinding = true;
 |};
 
-# Represents a public object identifier containing a unique ID string.
+# Represents a public object identifier containing a unique ID string
 public type PublicObjectId record {
-    # Unique identifier of the public object.
+    # Unique identifier of the public object
     string id;
 };
 
-# Pagination metadata containing cursors for navigating to next and previous pages.
+# Pagination metadata containing cursors for navigating to next and previous pages
 public type Paging record {
-    # Pagination cursor details for retrieving the next page of results.
+    # Pagination cursor details for retrieving the next page of results
     NextPage next?;
-    # Pagination cursor details for navigating to the previous page of results.
+    # Pagination cursor details for navigating to the previous page of results
     PreviousPage prev?;
 };
 
-# Request payload for searching products using filters, sorting, and pagination.
+# Request payload for searching products using filters, sorting, and pagination
 public type PublicObjectSearchRequest record {
-    # Full-text search query string to match against product records.
+    # Full-text search query string to match against product records
     string query?;
-    # Maximum number of results to return per page.
+    # Maximum number of results to return per page
     int:Signed32 'limit?;
-    # Cursor token for retrieving the next page of results.
+    # Cursor token for retrieving the next page of results
     string after?;
-    # List of sort criteria to order search results.
+    # List of sort criteria to order search results
     string[] sorts?;
-    # List of property names to include in the response.
+    # List of property names to include in the response
     string[] properties?;
-    # Groups of filters used to narrow search results.
+    # Groups of filters used to narrow search results
     FilterGroup[] filterGroups?;
 };
 
-# Input object for a batch upsert operation, containing the record identifier and a map of property values to create or update.
+# Input object for a batch upsert operation, containing the record identifier and a map of property values to create or update
 public type SimplePublicObjectBatchInputUpsert record {
     # The name of a property whose values are unique for this object
     string idProperty?;
-    # Trace identifier for tracking the object write operation.
+    # Trace identifier for tracking the object write operation
     string objectWriteTraceId?;
-    # The unique identifier of the record to upsert.
+    # The unique identifier of the record to upsert
     string id;
-    # Map of property names to values to set on the record.
+    # Map of property names to values to set on the record
     record {|string...;|} properties;
 };
 
@@ -328,165 +328,165 @@ public type PostBatchReadReadQueries record {
     boolean archived = false;
 };
 
-# Batch operation response containing processed product records, status, timing metadata, and any errors encountered during processing.
+# Batch operation response containing processed product records, status, timing metadata, and any errors encountered during processing
 public type BatchResponseSimplePublicObjectWithErrors record {
-    # Timestamp indicating when the batch operation completed.
+    # Timestamp indicating when the batch operation completed
     string completedAt;
-    # Total number of errors encountered during the batch operation.
+    # Total number of errors encountered during the batch operation
     int:Signed32 numErrors?;
-    # Timestamp indicating when the batch operation was requested.
+    # Timestamp indicating when the batch operation was requested
     string requestedAt?;
-    # Timestamp indicating when the batch operation started processing.
+    # Timestamp indicating when the batch operation started processing
     string startedAt;
-    # Map of related resource names to their associated URLs.
+    # Map of related resource names to their associated URLs
     record {|string...;|} links?;
-    # List of successfully processed product objects from the batch.
+    # List of successfully processed product objects from the batch
     SimplePublicObject[] results;
-    # List of errors encountered for individual records in the batch.
+    # List of errors encountered for individual records in the batch
     StandardError[] errors?;
-    # Current processing status of the batch operation.
+    # Current processing status of the batch operation
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
-# Input object for creating or updating a product, containing a map of property values and optional association definitions.
+# Input object for creating or updating a product, containing a map of property values and optional association definitions
 public type SimplePublicObjectInput record {
-    # Trace identifier for tracking the object write operation.
+    # Trace identifier for tracking the object write operation
     string objectWriteTraceId?;
-    # Key-value pairs of product property names and their string values.
+    # Key-value pairs of product property names and their string values
     record {|string...;|} properties;
 };
 
-# A paginated collection of product objects including their associated records.
+# A paginated collection of product objects including their associated records
 public type CollectionResponseSimplePublicObjectWithAssociationsForwardPaging record {
-    # Pagination object providing a cursor for retrieving the next page of results.
+    # Pagination object providing a cursor for retrieving the next page of results
     ForwardPaging paging?;
-    # Array of product objects returned in the current page.
+    # Array of product objects returned in the current page
     SimplePublicObjectWithAssociations[] results;
 };
 
-# Defines the category and type identifier for an object association.
+# Defines the category and type identifier for an object association
 public type AssociationSpec record {
-    # The category that defines the origin of the association type.
+    # The category that defines the origin of the association type
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" associationCategory;
-    # The numeric identifier for the specific association type.
+    # The numeric identifier for the specific association type
     int:Signed32 associationTypeId;
 };
 
-# A product object including its properties, timestamps, and related associations.
+# A product object including its properties, timestamps, and related associations
 public type SimplePublicObjectWithAssociations record {
-    # Map of associated object collections keyed by association type.
+    # Map of associated object collections keyed by association type
     record {|CollectionResponseAssociatedId...;|} associations?;
-    # Timestamp indicating when the product record was created.
+    # Timestamp indicating when the product record was created
     string createdAt;
-    # Indicates whether the product record is archived.
+    # Indicates whether the product record is archived
     boolean archived?;
-    # Timestamp indicating when the product record was archived.
+    # Timestamp indicating when the product record was archived
     string archivedAt?;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # The unique identifier of the product record.
+    # The unique identifier of the product record
     string id;
-    # Key-value map of product property names to their current string values.
+    # Key-value map of product property names to their current string values
     record {|string?...;|} properties;
-    # Timestamp indicating when the product record was last updated.
+    # Timestamp indicating when the product record was last updated
     string updatedAt;
 };
 
-# Defines a filter condition using a property, operator, and comparison value.
+# Defines a filter condition using a property, operator, and comparison value
 public type Filter record {
-    # The upper bound value used with the BETWEEN operator.
+    # The upper bound value used with the BETWEEN operator
     string highValue?;
-    # The name of the product property to filter on.
+    # The name of the product property to filter on
     string propertyName;
-    # List of values used with IN or NOT_IN operators.
+    # List of values used with IN or NOT_IN operators
     string[] values?;
-    # The value to compare against the filter property.
+    # The value to compare against the filter property
     string value?;
-    # The comparison operator used to evaluate the filter condition.
+    # The comparison operator used to evaluate the filter condition
     "EQ"|"NEQ"|"LT"|"LTE"|"GT"|"GTE"|"BETWEEN"|"IN"|"NOT_IN"|"HAS_PROPERTY"|"NOT_HAS_PROPERTY"|"CONTAINS_TOKEN"|"NOT_CONTAINS_TOKEN" operator;
 };
 
-# Pagination cursor details for navigating to the previous page of results.
+# Pagination cursor details for navigating to the previous page of results
 public type PreviousPage record {
-    # Cursor token representing the start of the previous page.
+    # Cursor token representing the start of the previous page
     string before;
-    # Direct URL link to the previous page of results.
+    # Direct URL link to the previous page of results
     string link?;
 };
 
-# A batch wrapper containing an array of product creation inputs to process together.
+# A batch wrapper containing an array of product creation inputs to process together
 public type BatchInputSimplePublicObjectInputForCreate record {
-    # Array of product creation input objects to process in batch.
+    # Array of product creation input objects to process in batch
     SimplePublicObjectInputForCreate[] inputs;
 };
 
-# A batch wrapper containing an array of product update inputs to process together.
+# A batch wrapper containing an array of product update inputs to process together
 public type BatchInputSimplePublicObjectBatchInput record {
-    # Array of product update input objects to process in batch.
+    # Array of product update input objects to process in batch
     SimplePublicObjectBatchInput[] inputs;
 };
 
-# Represents a product record returned after an upsert operation, indicating whether it was newly created.
+# Represents a product record returned after an upsert operation, indicating whether it was newly created
 public type SimplePublicUpsertObject record {
-    # Timestamp when the product record was created.
+    # Timestamp when the product record was created
     string createdAt;
-    # Indicates whether the product record is archived.
+    # Indicates whether the product record is archived
     boolean archived?;
-    # Timestamp when the product record was archived.
+    # Timestamp when the product record was archived
     string archivedAt?;
-    # Indicates whether the record was newly created by the upsert.
+    # Indicates whether the record was newly created by the upsert
     boolean 'new;
-    # Map of property names to their historical values with timestamps.
+    # Map of property names to their historical values with timestamps
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
-    # The unique identifier of the product record.
+    # The unique identifier of the product record
     string id;
-    # Map of property names to their current values for the product.
+    # Map of property names to their current values for the product
     record {|string...;|} properties;
-    # Timestamp when the product record was last updated.
+    # Timestamp when the product record was last updated
     string updatedAt;
 };
 
-# Defines a single product update payload, including the target record ID and properties to update.
+# Defines a single product update payload, including the target record ID and properties to update
 public type SimplePublicObjectBatchInput record {
     # The name of a property whose values are unique for this object
     string idProperty?;
-    # Trace identifier for tracking the write operation.
+    # Trace identifier for tracking the write operation
     string objectWriteTraceId?;
     # The id to be updated. This can be the object id, or the unique property value of the idProperty property
     string id;
-    # Key-value pairs of product property names and their string values.
+    # Key-value pairs of product property names and their string values
     record {|string...;|} properties;
 };
 
-# Pagination cursor details for retrieving the next page of results.
+# Pagination cursor details for retrieving the next page of results
 public type NextPage record {
-    # The relative URL link to the next page of results.
+    # The relative URL link to the next page of results
     string link?;
-    # The cursor token used to fetch the next page of results.
+    # The cursor token used to fetch the next page of results
     string after;
 };
 
-# Represents an associated object identified by its ID and association type.
+# Represents an associated object identified by its ID and association type
 public type AssociatedId record {
-    # The unique identifier of the associated object.
+    # The unique identifier of the associated object
     string id;
-    # The type defining the nature of the association.
+    # The type defining the nature of the association
     string 'type;
 };
 
-# Provides API key configurations needed when communicating with a remote HTTP endpoint.
+# Provides API key configurations needed when communicating with a remote HTTP endpoint
 public type ApiKeysConfig record {|
     string privateAppLegacy;
     string privateApp;
 |};
 
-# Input schema for creating a new product, including properties and associations.
+# Input schema for creating a new product, including properties and associations
 public type SimplePublicObjectInputForCreate record {
-    # List of associations linking this product to other CRM objects.
+    # List of associations linking this product to other CRM objects
     PublicAssociationsForObject[] associations?;
-    # Optional trace identifier for tracking the write operation.
+    # Optional trace identifier for tracking the write operation
     string objectWriteTraceId?;
-    # Key-value pairs of product property names and their string values.
+    # Key-value pairs of product property names and their string values
     record {|string...;|} properties?;
 };
 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -19,19 +19,31 @@
 
 import ballerina/http;
 
+# Standard error response structure returned by the API.
 public type StandardError record {
+    # Optional sub-category providing additional error classification.
     record {} subCategory?;
+    # Contextual metadata map with string array values for the error.
     record {|string[]...;|} context;
+    # Map of relevant links associated with the error response.
     record {|string...;|} links;
+    # Unique identifier for the error instance.
     string id?;
+    # High-level category classifying the type of error.
     string category;
+    # Human-readable message describing the error.
     string message;
+    # List of detailed error entries associated with this error.
     ErrorDetail[] errors;
+    # HTTP status code or status label for the error response.
     string status;
 };
 
+# Paginated collection of associated object IDs.
 public type CollectionResponseAssociatedId record {
+    # Pagination metadata containing cursors for navigating to next and previous pages.
     Paging paging?;
+    # Array of associated IDs returned in the response.
     AssociatedId[] results;
 };
 
@@ -41,21 +53,33 @@ public type PatchProductIdUpdateQueries record {
     string idProperty?;
 };
 
+# Defines the target object and association types for a relationship.
 public type PublicAssociationsForObject record {
+    # List of association type specifications for the relationship.
     AssociationSpec[] types;
+    # Represents a public object identifier containing a unique ID string.
     PublicObjectId to;
 };
 
+# Batch operation response containing product objects and status.
 public type BatchResponseSimplePublicObject record {
+    # Timestamp when the batch operation completed.
     string completedAt;
+    # Timestamp when the batch operation was requested.
     string requestedAt?;
+    # Timestamp when the batch operation started processing.
     string startedAt;
+    # Map of relevant links related to the batch response.
     record {|string...;|} links?;
+    # List of product objects returned in the batch response.
     SimplePublicObject[] results;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A logical grouping of filters applied together when searching products.
 public type FilterGroup record {
+    # List of filter conditions within this filter group.
     Filter[] filters;
 };
 
@@ -75,6 +99,7 @@ public type GetGetPageQueries record {
     string[] properties?;
 };
 
+# Detailed information about a specific error encountered during a request.
 public type ErrorDetail record {
     # A specific category that contains more specific detail about the error
     string subCategory?;
@@ -88,52 +113,85 @@ public type ErrorDetail record {
     string message;
 };
 
+# Pagination object providing a cursor for retrieving the next page of results.
 public type ForwardPaging record {
+    # Pagination cursor details for retrieving the next page of results.
     NextPage next?;
 };
 
+# A minimal object representation containing only a unique identifier.
 public type SimplePublicObjectId record {
+    # The unique identifier of the product object.
     string id;
 };
 
+# Batch upsert response containing results, status, timing metadata, and any errors encountered.
 public type BatchResponseSimplePublicUpsertObjectWithErrors record {
+    # Timestamp when the batch operation completed.
     string completedAt;
+    # Total number of errors encountered during the batch operation.
     int:Signed32 numErrors?;
+    # Timestamp when the batch operation was requested.
     string requestedAt?;
+    # Timestamp when the batch operation began processing.
     string startedAt;
+    # Map of relevant hyperlinks associated with the batch response.
     record {|string...;|} links?;
+    # List of upserted product objects returned in the batch response.
     SimplePublicUpsertObject[] results;
+    # List of errors encountered for individual records in the batch.
     StandardError[] errors?;
+    # Current processing status of the batch upsert operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Input payload for batch reading products by ID, specifying properties to retrieve.
 public type BatchReadInputSimplePublicObjectId record {
+    # List of properties for which to return historical values.
     string[] propertiesWithHistory;
     # The name of a property whose values are unique for this object
     string idProperty?;
+    # List of object IDs to retrieve in the batch request.
     SimplePublicObjectId[] inputs;
+    # List of property names to include in the response.
     string[] properties;
 };
 
+# Response object containing the status, timing, and results of a batch upsert operation on products.
 public type BatchResponseSimplePublicUpsertObject record {
+    # Timestamp when the batch operation completed.
     string completedAt;
+    # Timestamp when the batch operation was requested.
     string requestedAt?;
+    # Timestamp when the batch operation began processing.
     string startedAt;
+    # Map of related resource links associated with the batch response.
     record {|string...;|} links?;
+    # Collection of upserted product objects returned by the batch operation.
     SimplePublicUpsertObject[] results;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# A property value paired with its source information and the timestamp of the last update.
 public type ValueWithTimestamp record {
+    # Identifier of the source that set this property value.
     string sourceId?;
+    # Type of source that last updated this property value.
     string sourceType;
+    # Human-readable label describing the source of the value.
     string sourceLabel?;
+    # ID of the user who last updated this property value.
     int:Signed32 updatedByUserId?;
+    # The property value associated with the given timestamp.
     string value;
+    # Timestamp when this property value was last updated.
     string timestamp;
 };
 
+# Input schema for a batch operation containing a list of product object IDs.
 public type BatchInputSimplePublicObjectId record {
+    # List of product object IDs to process in the batch operation.
     SimplePublicObjectId[] inputs;
 };
 
@@ -144,23 +202,37 @@ public type OAuth2RefreshTokenGrantConfig record {|
     string refreshUrl = "https://api.hubapi.com/oauth/v1/token";
 |};
 
+# Input schema for a batch upsert operation containing a list of product objects to create or update.
 public type BatchInputSimplePublicObjectBatchInputUpsert record {
+    # List of product objects to create or update in the batch upsert.
     SimplePublicObjectBatchInputUpsert[] inputs;
 };
 
+# Paginated collection of product objects with a total count and forward paging cursor.
 public type CollectionResponseWithTotalSimplePublicObjectForwardPaging record {
+    # Total number of results matching the request.
     int:Signed32 total;
+    # Pagination object providing a cursor for retrieving the next page of results.
     ForwardPaging paging?;
+    # Array of product objects returned in the current page.
     SimplePublicObject[] results;
 };
 
+# Represents a product record with its properties, timestamps, and archival status.
 public type SimplePublicObject record {
+    # Timestamp when the product record was created.
     string createdAt;
+    # Indicates whether the product record is archived.
     boolean archived?;
+    # Timestamp when the product record was archived.
     string archivedAt?;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # Unique identifier of the product record.
     string id;
+    # Map of property names to their current values for the product.
     record {|string?...;|} properties;
+    # Timestamp when the product record was last updated.
     string updatedAt;
 };
 
@@ -208,29 +280,45 @@ public type ConnectionConfig record {|
     boolean laxDataBinding = true;
 |};
 
+# Represents a public object identifier containing a unique ID string.
 public type PublicObjectId record {
+    # Unique identifier of the public object.
     string id;
 };
 
+# Pagination metadata containing cursors for navigating to next and previous pages.
 public type Paging record {
+    # Pagination cursor details for retrieving the next page of results.
     NextPage next?;
+    # Pagination cursor details for navigating to the previous page of results.
     PreviousPage prev?;
 };
 
+# Request payload for searching products using filters, sorting, and pagination.
 public type PublicObjectSearchRequest record {
+    # Full-text search query string to match against product records.
     string query?;
+    # Maximum number of results to return per page.
     int:Signed32 'limit?;
+    # Cursor token for retrieving the next page of results.
     string after?;
+    # List of sort criteria to order search results.
     string[] sorts?;
+    # List of property names to include in the response.
     string[] properties?;
+    # Groups of filters used to narrow search results.
     FilterGroup[] filterGroups?;
 };
 
+# Input object for a batch upsert operation, containing the record identifier and a map of property values to create or update.
 public type SimplePublicObjectBatchInputUpsert record {
     # The name of a property whose values are unique for this object
     string idProperty?;
+    # Trace identifier for tracking the object write operation.
     string objectWriteTraceId?;
+    # The unique identifier of the record to upsert.
     string id;
+    # Map of property names to values to set on the record.
     record {|string...;|} properties;
 };
 
@@ -240,92 +328,149 @@ public type PostBatchReadReadQueries record {
     boolean archived = false;
 };
 
+# Batch operation response containing processed product records, status, timing metadata, and any errors encountered during processing.
 public type BatchResponseSimplePublicObjectWithErrors record {
+    # Timestamp indicating when the batch operation completed.
     string completedAt;
+    # Total number of errors encountered during the batch operation.
     int:Signed32 numErrors?;
+    # Timestamp indicating when the batch operation was requested.
     string requestedAt?;
+    # Timestamp indicating when the batch operation started processing.
     string startedAt;
+    # Map of related resource names to their associated URLs.
     record {|string...;|} links?;
+    # List of successfully processed product objects from the batch.
     SimplePublicObject[] results;
+    # List of errors encountered for individual records in the batch.
     StandardError[] errors?;
+    # Current processing status of the batch operation.
     "PENDING"|"PROCESSING"|"CANCELED"|"COMPLETE" status;
 };
 
+# Input object for creating or updating a product, containing a map of property values and optional association definitions.
 public type SimplePublicObjectInput record {
+    # Trace identifier for tracking the object write operation.
     string objectWriteTraceId?;
+    # Key-value pairs of product property names and their string values.
     record {|string...;|} properties;
 };
 
+# A paginated collection of product objects including their associated records.
 public type CollectionResponseSimplePublicObjectWithAssociationsForwardPaging record {
+    # Pagination object providing a cursor for retrieving the next page of results.
     ForwardPaging paging?;
+    # Array of product objects returned in the current page.
     SimplePublicObjectWithAssociations[] results;
 };
 
+# Defines the category and type identifier for an object association.
 public type AssociationSpec record {
+    # The category that defines the origin of the association type.
     "HUBSPOT_DEFINED"|"USER_DEFINED"|"INTEGRATOR_DEFINED" associationCategory;
+    # The numeric identifier for the specific association type.
     int:Signed32 associationTypeId;
 };
 
+# A product object including its properties, timestamps, and related associations.
 public type SimplePublicObjectWithAssociations record {
+    # Map of associated object collections keyed by association type.
     record {|CollectionResponseAssociatedId...;|} associations?;
+    # Timestamp indicating when the product record was created.
     string createdAt;
+    # Indicates whether the product record is archived.
     boolean archived?;
+    # Timestamp indicating when the product record was archived.
     string archivedAt?;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # The unique identifier of the product record.
     string id;
+    # Key-value map of product property names to their current string values.
     record {|string?...;|} properties;
+    # Timestamp indicating when the product record was last updated.
     string updatedAt;
 };
 
+# Defines a filter condition using a property, operator, and comparison value.
 public type Filter record {
+    # The upper bound value used with the BETWEEN operator.
     string highValue?;
+    # The name of the product property to filter on.
     string propertyName;
+    # List of values used with IN or NOT_IN operators.
     string[] values?;
+    # The value to compare against the filter property.
     string value?;
-    # null
+    # The comparison operator used to evaluate the filter condition.
     "EQ"|"NEQ"|"LT"|"LTE"|"GT"|"GTE"|"BETWEEN"|"IN"|"NOT_IN"|"HAS_PROPERTY"|"NOT_HAS_PROPERTY"|"CONTAINS_TOKEN"|"NOT_CONTAINS_TOKEN" operator;
 };
 
+# Pagination cursor details for navigating to the previous page of results.
 public type PreviousPage record {
+    # Cursor token representing the start of the previous page.
     string before;
+    # Direct URL link to the previous page of results.
     string link?;
 };
 
+# A batch wrapper containing an array of product creation inputs to process together.
 public type BatchInputSimplePublicObjectInputForCreate record {
+    # Array of product creation input objects to process in batch.
     SimplePublicObjectInputForCreate[] inputs;
 };
 
+# A batch wrapper containing an array of product update inputs to process together.
 public type BatchInputSimplePublicObjectBatchInput record {
+    # Array of product update input objects to process in batch.
     SimplePublicObjectBatchInput[] inputs;
 };
 
+# Represents a product record returned after an upsert operation, indicating whether it was newly created.
 public type SimplePublicUpsertObject record {
+    # Timestamp when the product record was created.
     string createdAt;
+    # Indicates whether the product record is archived.
     boolean archived?;
+    # Timestamp when the product record was archived.
     string archivedAt?;
+    # Indicates whether the record was newly created by the upsert.
     boolean 'new;
+    # Map of property names to their historical values with timestamps.
     record {|ValueWithTimestamp[]...;|} propertiesWithHistory?;
+    # The unique identifier of the product record.
     string id;
+    # Map of property names to their current values for the product.
     record {|string...;|} properties;
+    # Timestamp when the product record was last updated.
     string updatedAt;
 };
 
+# Defines a single product update payload, including the target record ID and properties to update.
 public type SimplePublicObjectBatchInput record {
     # The name of a property whose values are unique for this object
     string idProperty?;
+    # Trace identifier for tracking the write operation.
     string objectWriteTraceId?;
     # The id to be updated. This can be the object id, or the unique property value of the idProperty property
     string id;
+    # Key-value pairs of product property names and their string values.
     record {|string...;|} properties;
 };
 
+# Pagination cursor details for retrieving the next page of results.
 public type NextPage record {
+    # The relative URL link to the next page of results.
     string link?;
+    # The cursor token used to fetch the next page of results.
     string after;
 };
 
+# Represents an associated object identified by its ID and association type.
 public type AssociatedId record {
+    # The unique identifier of the associated object.
     string id;
+    # The type defining the nature of the association.
     string 'type;
 };
 
@@ -335,9 +480,13 @@ public type ApiKeysConfig record {|
     string privateApp;
 |};
 
+# Input schema for creating a new product, including properties and associations.
 public type SimplePublicObjectInputForCreate record {
+    # List of associations linking this product to other CRM objects.
     PublicAssociationsForObject[] associations?;
+    # Optional trace identifier for tracking the write operation.
     string objectWriteTraceId?;
+    # Key-value pairs of product property names and their string values.
     record {|string...;|} properties?;
 };
 

--- a/docs/spec/aligned_ballerina_openapi.json
+++ b/docs/spec/aligned_ballerina_openapi.json
@@ -1,0 +1,2126 @@
+{
+    "openapi": "3.0.1",
+    "info": {
+        "title": "Products",
+        "description": "",
+        "version": "v3",
+        "x-hubspot-product-tier-requirements": {
+            "marketing": "FREE",
+            "sales": "FREE",
+            "service": "FREE",
+            "cms": "FREE"
+        },
+        "x-hubspot-documentation-banner": "NONE",
+        "x-hubspot-api-use-case": "To prepare for an upcoming product launch, use the products API to create a set of products to represent your new offerings. Sales reps can then use these products when creating payment links, invoices, and more.",
+        "x-hubspot-related-documentation": [
+            {
+                "name": "Products Guide",
+                "url": "https://developers.hubspot.com/beta-docs/guides/api/crm/objects/products"
+            }
+        ],
+        "x-hubspot-introduction": "Use the products API to create and manage your product library, which is the collection of goods and services that your company offers. Products in your product library can be used as line items when creating deals, payment links, invoices, and quotes."
+    },
+    "servers": [
+        {
+            "url": "https://api.hubapi.com/crm/v3/objects/products"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Batch"
+        },
+        {
+            "name": "Basic"
+        },
+        {
+            "name": "Search"
+        }
+    ],
+    "paths": {
+        "/batch/read": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Read products by ID or property",
+                "operationId": "post-/batch/read_read",
+                "parameters": [
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchReadInputSimplePublicObjectId"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ],
+                "description": "Returns a batch of products matching the provided internal IDs or unique property values, with partial success indicated by a 207 response."
+            }
+        },
+        "/{productId}": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Retrieve a product by ID",
+                "description": "Read an Object identified by `{productId}`. `{productId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.",
+                "operationId": "get-/{productId}_getById",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique internal identifier of the product to retrieve."
+                    },
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "propertiesWithHistory",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "associations",
+                        "in": "query",
+                        "description": "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    },
+                    {
+                        "name": "idProperty",
+                        "in": "query",
+                        "description": "The name of a property whose values are unique for this object",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObjectWithAssociations"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ]
+            },
+            "delete": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Archive a product by ID",
+                "description": "Move an Object identified by `{productId}` to the recycling bin.",
+                "operationId": "delete-/{productId}_archive",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique internal identifier of the product to archive."
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ]
+            },
+            "patch": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Partially update a product",
+                "description": "Perform a partial update of an Object identified by `{productId}`. `{productId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will result in an error. Properties values can be cleared by passing an empty string.",
+                "operationId": "patch-/{productId}_update",
+                "parameters": [
+                    {
+                        "name": "productId",
+                        "in": "path",
+                        "required": true,
+                        "style": "simple",
+                        "explode": false,
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique internal identifier of the product to update."
+                    },
+                    {
+                        "name": "idProperty",
+                        "in": "query",
+                        "description": "The name of a property whose values are unique for this object",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplePublicObjectInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/archive": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Archive a batch of products by ID",
+                "operationId": "post-/batch/archive_archive",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectId"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "204": {
+                        "description": "No content",
+                        "content": {}
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ],
+                "description": "Returns no content upon successfully archiving the specified batch of products."
+            }
+        },
+        "/batch/create": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Create a batch of products",
+                "operationId": "post-/batch/create_create",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectInputForCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ],
+                "description": "Returns the newly created batch of products, with partial success indicated by a 207 response."
+            }
+        },
+        "/batch/update": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Update a batch of products",
+                "operationId": "post-/batch/update_update",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectBatchInput"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ],
+                "description": "Returns the updated batch of products matched by internal ID or unique property values, with partial success indicated by a 207 response."
+            }
+        },
+        "/": {
+            "get": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Retrieve a page of products",
+                "description": "Read a page of products. Control what is returned via the `properties` query param.",
+                "operationId": "get-_getPage",
+                "parameters": [
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The maximum number of results to display per page",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32",
+                            "default": 10
+                        }
+                    },
+                    {
+                        "name": "after",
+                        "in": "query",
+                        "description": "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "properties",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "propertiesWithHistory",
+                        "in": "query",
+                        "description": "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored. Usage of this parameter will reduce the maximum number of objects that can be read by a single request",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "associations",
+                        "in": "query",
+                        "description": "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "name": "archived",
+                        "in": "query",
+                        "description": "Whether to return only results that have been archived",
+                        "required": false,
+                        "style": "form",
+                        "explode": true,
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseSimplePublicObjectWithAssociationsForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Basic"
+                ],
+                "summary": "Create a new product",
+                "description": "Create a product with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard products is provided.",
+                "operationId": "post-_create",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/SimplePublicObjectInputForCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "201": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/SimplePublicObject"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/batch/upsert": {
+            "post": {
+                "tags": [
+                    "Batch"
+                ],
+                "summary": "Upsert a batch of products",
+                "description": "Create or update records identified by a unique property value as specified by the `idProperty` query param. `idProperty` query param refers to a property whose values are unique for the object.",
+                "operationId": "post-/batch/upsert_upsert",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/BatchInputSimplePublicObjectBatchInputUpsert"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicUpsertObject"
+                                }
+                            }
+                        }
+                    },
+                    "207": {
+                        "description": "multiple statuses",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/BatchResponseSimplePublicUpsertObjectWithErrors"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ]
+            }
+        },
+        "/search": {
+            "post": {
+                "tags": [
+                    "Search"
+                ],
+                "operationId": "post-/search_doSearch",
+                "parameters": [],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PublicObjectSearchRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "responses": {
+                    "200": {
+                        "description": "successful operation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CollectionResponseWithTotalSimplePublicObjectForwardPaging"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "$ref": "#/components/responses/Error"
+                    }
+                },
+                "security": [
+                    {
+                        "oauth2_legacy": [
+                            "e-commerce"
+                        ]
+                    },
+                    {
+                        "private_apps_legacy": [
+                            "e-commerce"
+                        ]
+                    }
+                ],
+                "x-hubspot-rate-limit-exemptions": [
+                    "ten-secondly"
+                ],
+                "description": "Returns a list of products matching the specified search criteria and filters.",
+                "summary": "Search for products"
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "StandardError": {
+                "required": [
+                    "category",
+                    "context",
+                    "errors",
+                    "links",
+                    "message",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "object",
+                        "properties": {},
+                        "description": "Optional sub-category providing additional error classification."
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Contextual metadata map with string array values for the error."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links associated with the error response."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier for the error instance."
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "High-level category classifying the type of error."
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "Human-readable message describing the error."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        },
+                        "description": "List of detailed error entries associated with this error."
+                    },
+                    "status": {
+                        "type": "string",
+                        "description": "HTTP status code or status label for the error response."
+                    }
+                },
+                "description": "Standard error response structure returned by the API."
+            },
+            "CollectionResponseAssociatedId": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/Paging",
+                        "description": "Paging metadata for navigating the result set."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssociatedId"
+                        },
+                        "description": "Array of associated IDs returned in the response."
+                    }
+                },
+                "description": "Paginated collection of associated object IDs."
+            },
+            "PublicAssociationsForObject": {
+                "required": [
+                    "to",
+                    "types"
+                ],
+                "type": "object",
+                "properties": {
+                    "types": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AssociationSpec"
+                        },
+                        "description": "List of association type specifications for the relationship."
+                    },
+                    "to": {
+                        "$ref": "#/components/schemas/PublicObjectId",
+                        "description": "The target object to associate with."
+                    }
+                },
+                "description": "Defines the target object and association types for a relationship."
+            },
+            "BatchResponseSimplePublicObject": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant links related to the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "List of product objects returned in the batch response."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch operation response containing product objects and status."
+            },
+            "FilterGroup": {
+                "required": [
+                    "filters"
+                ],
+                "type": "object",
+                "properties": {
+                    "filters": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Filter"
+                        },
+                        "description": "List of filter conditions within this filter group."
+                    }
+                },
+                "description": "A logical grouping of filters applied together when searching products."
+            },
+            "ErrorDetail": {
+                "required": [
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "code": {
+                        "type": "string",
+                        "description": "The status code associated with the error detail"
+                    },
+                    "in": {
+                        "type": "string",
+                        "description": "The name of the field or parameter in which the error was found"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ]
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate"
+                    }
+                },
+                "description": "Detailed information about a specific error encountered during a request."
+            },
+            "ForwardPaging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor and link information for retrieving the next page."
+                    }
+                },
+                "description": "Pagination object providing a cursor for retrieving the next page of results."
+            },
+            "SimplePublicObjectId": {
+                "required": [
+                    "id"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the product object."
+                    }
+                },
+                "description": "A minimal object representation containing only a unique identifier."
+            },
+            "BatchResponseSimplePublicUpsertObjectWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of relevant hyperlinks associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicUpsertObject"
+                        },
+                        "description": "List of upserted product objects returned in the batch response."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch upsert operation."
+                    }
+                },
+                "description": "Batch upsert response containing results, status, timing metadata, and any errors encountered."
+            },
+            "BatchReadInputSimplePublicObjectId": {
+                "required": [
+                    "inputs",
+                    "properties",
+                    "propertiesWithHistory"
+                ],
+                "type": "object",
+                "properties": {
+                    "propertiesWithHistory": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of properties for which to return historical values."
+                    },
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The name of a property whose values are unique for this object"
+                    },
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectId"
+                        },
+                        "description": "List of object IDs to retrieve in the batch request."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the response."
+                    }
+                },
+                "description": "Input payload for batch reading products by ID, specifying properties to retrieve."
+            },
+            "BatchResponseSimplePublicUpsertObject": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation completed."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the batch operation began processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource links associated with the batch response."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicUpsertObject"
+                        },
+                        "description": "Collection of upserted product objects returned by the batch operation."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Response object containing the status, timing, and results of a batch upsert operation on products."
+            },
+            "BatchInputSimplePublicObjectId": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectId"
+                        },
+                        "description": "List of product object IDs to process in the batch operation."
+                    }
+                },
+                "description": "Input schema for a batch operation containing a list of product object IDs."
+            },
+            "ValueWithTimestamp": {
+                "required": [
+                    "sourceType",
+                    "timestamp",
+                    "value"
+                ],
+                "type": "object",
+                "properties": {
+                    "sourceId": {
+                        "type": "string",
+                        "description": "Identifier of the source that set this property value."
+                    },
+                    "sourceType": {
+                        "type": "string",
+                        "description": "Type of source that last updated this property value."
+                    },
+                    "sourceLabel": {
+                        "type": "string",
+                        "description": "Human-readable label describing the source of the value."
+                    },
+                    "updatedByUserId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "ID of the user who last updated this property value."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The property value associated with the given timestamp."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when this property value was last updated."
+                    }
+                },
+                "description": "A property value paired with its source information and the timestamp of the last update."
+            },
+            "BatchInputSimplePublicObjectBatchInputUpsert": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectBatchInputUpsert"
+                        },
+                        "description": "List of product objects to create or update in the batch upsert."
+                    }
+                },
+                "description": "Input schema for a batch upsert operation containing a list of product objects to create or update."
+            },
+            "CollectionResponseWithTotalSimplePublicObjectForwardPaging": {
+                "required": [
+                    "results",
+                    "total"
+                ],
+                "type": "object",
+                "properties": {
+                    "total": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of results matching the request."
+                    },
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Forward paging cursor for retrieving the next page of results."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "Array of product objects returned in the current page."
+                    }
+                },
+                "description": "Paginated collection of product objects with a total count and forward paging cursor."
+            },
+            "SimplePublicObject": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the product record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "example": false,
+                        "description": "Indicates whether the product record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the product record was archived."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "example": "512",
+                        "description": "Unique identifier of the product record."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "example": {
+                            "property_date": "1572480000000",
+                            "property_radio": "option_1",
+                            "property_number": "17",
+                            "property_string": "value",
+                            "property_checkbox": "false",
+                            "property_dropdown": "choice_b",
+                            "property_multiple_checkboxes": "chocolate;strawberry"
+                        },
+                        "description": "Map of property names to their current values for the product."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the product record was last updated."
+                    }
+                },
+                "example": {
+                    "id": "512",
+                    "properties": {
+                        "createdate": "2019-10-30T03:30:17.883Z",
+                        "description": "Onboarding service for data product",
+                        "hs_cost_of_goods_sold": "600.00",
+                        "hs_lastmodifieddate": "2019-12-07T16:50:06.678Z",
+                        "hs_recurring_billing_period": "12",
+                        "hs_sku": "191902",
+                        "name": "Implementation Service ",
+                        "price": "6000.00"
+                    },
+                    "createdAt": "2019-10-30T03:30:17.883Z",
+                    "updatedAt": "2019-12-07T16:50:06.678Z",
+                    "archived": false
+                },
+                "description": "Represents a product record with its properties, timestamps, and archival status."
+            },
+            "PublicObjectId": {
+                "required": [
+                    "id"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the public object."
+                    }
+                },
+                "description": "Represents a public object identifier containing a unique ID string."
+            },
+            "Paging": {
+                "type": "object",
+                "properties": {
+                    "next": {
+                        "$ref": "#/components/schemas/NextPage",
+                        "description": "Cursor and link for retrieving the next page of results."
+                    },
+                    "prev": {
+                        "$ref": "#/components/schemas/PreviousPage",
+                        "description": "Cursor and link for retrieving the previous page of results."
+                    }
+                },
+                "description": "Pagination metadata containing cursors for navigating to next and previous pages."
+            },
+            "PublicObjectSearchRequest": {
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Full-text search query string to match against product records."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Maximum number of results to return per page."
+                    },
+                    "after": {
+                        "type": "string",
+                        "description": "Cursor token for retrieving the next page of results."
+                    },
+                    "sorts": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of sort criteria to order search results."
+                    },
+                    "properties": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of property names to include in the response."
+                    },
+                    "filterGroups": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/FilterGroup"
+                        },
+                        "description": "Groups of filters used to narrow search results."
+                    }
+                },
+                "description": "Request payload for searching products using filters, sorting, and pagination."
+            },
+            "Error": {
+                "required": [
+                    "category",
+                    "correlationId",
+                    "message"
+                ],
+                "type": "object",
+                "properties": {
+                    "subCategory": {
+                        "type": "string",
+                        "description": "A specific category that contains more specific detail about the error"
+                    },
+                    "context": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "description": "Context about the error condition",
+                        "example": {
+                            "missingScopes": [
+                                "scope1",
+                                "scope2"
+                            ],
+                            "invalidPropertyName": [
+                                "propertyValue"
+                            ]
+                        }
+                    },
+                    "correlationId": {
+                        "type": "string",
+                        "description": "A unique identifier for the request. Include this value with any error reports or support tickets",
+                        "format": "uuid",
+                        "example": "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+                        "example": {
+                            "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                        }
+                    },
+                    "message": {
+                        "type": "string",
+                        "description": "A human readable message describing the error along with remediation steps where appropriate",
+                        "example": "Invalid input (details will vary based on the error)"
+                    },
+                    "category": {
+                        "type": "string",
+                        "description": "The error category",
+                        "example": "VALIDATION_ERROR"
+                    },
+                    "errors": {
+                        "type": "array",
+                        "description": "further information about the error",
+                        "items": {
+                            "$ref": "#/components/schemas/ErrorDetail"
+                        }
+                    }
+                },
+                "example": {
+                    "message": "Invalid input (details will vary based on the error)",
+                    "correlationId": "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+                    "category": "VALIDATION_ERROR",
+                    "links": {
+                        "knowledge-base": "https://www.hubspot.com/products/service/knowledge-base"
+                    }
+                },
+                "description": "Represents an API error response, including a category, human-readable message, correlation ID for tracing, and optional contextual details or remediation links."
+            },
+            "SimplePublicObjectBatchInputUpsert": {
+                "required": [
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The name of a property whose values are unique for this object"
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the object write operation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the record to upsert."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "example": {
+                            "name": "Coffee",
+                            "price": "10.00",
+                            "hs_sku": "121212"
+                        },
+                        "description": "Map of property names to values to set on the record."
+                    }
+                },
+                "description": "Input object for a batch upsert operation, containing the record identifier and a map of property values to create or update."
+            },
+            "BatchResponseSimplePublicObjectWithErrors": {
+                "required": [
+                    "completedAt",
+                    "results",
+                    "startedAt",
+                    "status"
+                ],
+                "type": "object",
+                "properties": {
+                    "completedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation completed."
+                    },
+                    "numErrors": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "Total number of errors encountered during the batch operation."
+                    },
+                    "requestedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation was requested."
+                    },
+                    "startedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the batch operation started processing."
+                    },
+                    "links": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of related resource names to their associated URLs."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObject"
+                        },
+                        "description": "List of successfully processed product objects from the batch."
+                    },
+                    "errors": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/StandardError"
+                        },
+                        "description": "List of errors encountered for individual records in the batch."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "PENDING",
+                            "PROCESSING",
+                            "CANCELED",
+                            "COMPLETE"
+                        ],
+                        "description": "Current processing status of the batch operation."
+                    }
+                },
+                "description": "Batch operation response containing processed product records, status, timing metadata, and any errors encountered during processing."
+            },
+            "SimplePublicObjectInput": {
+                "required": [
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the object write operation."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "example": {
+                            "property_date": "1572480000000",
+                            "property_radio": "option_1",
+                            "property_number": "17",
+                            "property_string": "value",
+                            "property_checkbox": "false",
+                            "property_dropdown": "choice_b",
+                            "property_multiple_checkboxes": "chocolate;strawberry"
+                        },
+                        "description": "Key-value pairs of product property names and their string values."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "name": "Implementation Service ",
+                        "price": "6000.00",
+                        "hs_sku": "191902",
+                        "description": "Onboarding service for data product",
+                        "hs_cost_of_goods_sold": "600.00",
+                        "hs_recurring_billing_period": "12"
+                    },
+                    "associations": [
+                        {
+                            "to": {
+                                "id": "101"
+                            },
+                            "types": [
+                                {
+                                    "associationCategory": "HUBSPOT_DEFINED",
+                                    "associationTypeId": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "Input object for creating or updating a product, containing a map of property values and optional association definitions."
+            },
+            "CollectionResponseSimplePublicObjectWithAssociationsForwardPaging": {
+                "required": [
+                    "results"
+                ],
+                "type": "object",
+                "properties": {
+                    "paging": {
+                        "$ref": "#/components/schemas/ForwardPaging",
+                        "description": "Pagination cursor for retrieving the next page of results."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectWithAssociations"
+                        },
+                        "description": "Array of product objects returned in the current page."
+                    }
+                },
+                "description": "A paginated collection of product objects including their associated records."
+            },
+            "AssociationSpec": {
+                "required": [
+                    "associationCategory",
+                    "associationTypeId"
+                ],
+                "type": "object",
+                "properties": {
+                    "associationCategory": {
+                        "type": "string",
+                        "enum": [
+                            "HUBSPOT_DEFINED",
+                            "USER_DEFINED",
+                            "INTEGRATOR_DEFINED"
+                        ],
+                        "description": "The category that defines the origin of the association type."
+                    },
+                    "associationTypeId": {
+                        "type": "integer",
+                        "format": "int32",
+                        "description": "The numeric identifier for the specific association type."
+                    }
+                },
+                "description": "Defines the category and type identifier for an object association."
+            },
+            "SimplePublicObjectWithAssociations": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/components/schemas/CollectionResponseAssociatedId"
+                        },
+                        "description": "Map of associated object collections keyed by association type."
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the product record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Indicates whether the product record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the product record was archived."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the product record."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string",
+                            "nullable": true
+                        },
+                        "description": "Key-value map of product property names to their current string values."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp indicating when the product record was last updated."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "createdate": "2019-10-30T03:30:17.883Z",
+                        "description": "Onboarding service for data product",
+                        "hs_cost_of_goods_sold": "600.00",
+                        "hs_lastmodifieddate": "2019-12-07T16:50:06.678Z",
+                        "hs_recurring_billing_period": "12",
+                        "hs_sku": "191902",
+                        "name": "Implementation Service ",
+                        "price": "6000.00"
+                    }
+                },
+                "description": "A product object including its properties, timestamps, and related associations."
+            },
+            "Filter": {
+                "required": [
+                    "operator",
+                    "propertyName"
+                ],
+                "type": "object",
+                "properties": {
+                    "highValue": {
+                        "type": "string",
+                        "description": "The upper bound value used with the BETWEEN operator."
+                    },
+                    "propertyName": {
+                        "type": "string",
+                        "description": "The name of the product property to filter on."
+                    },
+                    "values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "List of values used with IN or NOT_IN operators."
+                    },
+                    "value": {
+                        "type": "string",
+                        "description": "The value to compare against the filter property."
+                    },
+                    "operator": {
+                        "type": "string",
+                        "description": "The comparison operator used to evaluate the filter condition.",
+                        "enum": [
+                            "EQ",
+                            "NEQ",
+                            "LT",
+                            "LTE",
+                            "GT",
+                            "GTE",
+                            "BETWEEN",
+                            "IN",
+                            "NOT_IN",
+                            "HAS_PROPERTY",
+                            "NOT_HAS_PROPERTY",
+                            "CONTAINS_TOKEN",
+                            "NOT_CONTAINS_TOKEN"
+                        ]
+                    }
+                },
+                "description": "Defines a filter condition using a property, operator, and comparison value."
+            },
+            "BatchInputSimplePublicObjectBatchInput": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectBatchInput"
+                        },
+                        "description": "Array of product update input objects to process in batch."
+                    }
+                },
+                "description": "A batch wrapper containing an array of product update inputs to process together."
+            },
+            "BatchInputSimplePublicObjectInputForCreate": {
+                "required": [
+                    "inputs"
+                ],
+                "type": "object",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/SimplePublicObjectInputForCreate"
+                        },
+                        "description": "Array of product creation input objects to process in batch."
+                    }
+                },
+                "description": "A batch wrapper containing an array of product creation inputs to process together."
+            },
+            "PreviousPage": {
+                "required": [
+                    "before"
+                ],
+                "type": "object",
+                "properties": {
+                    "before": {
+                        "type": "string",
+                        "description": "Cursor token representing the start of the previous page."
+                    },
+                    "link": {
+                        "type": "string",
+                        "description": "Direct URL link to the previous page of results."
+                    }
+                },
+                "description": "Pagination cursor details for navigating to the previous page of results."
+            },
+            "SimplePublicUpsertObject": {
+                "required": [
+                    "createdAt",
+                    "id",
+                    "new",
+                    "properties",
+                    "updatedAt"
+                ],
+                "type": "object",
+                "properties": {
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the product record was created."
+                    },
+                    "archived": {
+                        "type": "boolean",
+                        "description": "Indicates whether the product record is archived."
+                    },
+                    "archivedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the product record was archived."
+                    },
+                    "new": {
+                        "type": "boolean",
+                        "description": "Indicates whether the record was newly created by the upsert."
+                    },
+                    "propertiesWithHistory": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ValueWithTimestamp"
+                            }
+                        },
+                        "description": "Map of property names to their historical values with timestamps."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the product record."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "description": "Map of property names to their current values for the product."
+                    },
+                    "updatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Timestamp when the product record was last updated."
+                    }
+                },
+                "description": "Represents a product record returned after an upsert operation, indicating whether it was newly created."
+            },
+            "SimplePublicObjectBatchInput": {
+                "required": [
+                    "id",
+                    "properties"
+                ],
+                "type": "object",
+                "properties": {
+                    "idProperty": {
+                        "type": "string",
+                        "description": "The name of a property whose values are unique for this object",
+                        "example": "my_unique_property_name"
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Trace identifier for tracking the write operation."
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The id to be updated. This can be the object id, or the unique property value of the idProperty property"
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "example": {
+                            "name": "Coffee",
+                            "price": "10.00",
+                            "hs_sku": "121212"
+                        },
+                        "description": "Key-value pairs of product property names and their string values."
+                    }
+                },
+                "example": {
+                    "id": "1",
+                    "properties": {
+                        "name": "Implementation Service ",
+                        "price": "6000.00",
+                        "hs_sku": "191902",
+                        "description": "Onboarding service for data product",
+                        "hs_cost_of_goods_sold": "600.00",
+                        "hs_recurring_billing_period": "12"
+                    }
+                },
+                "description": "Defines a single product update payload, including the target record ID and properties to update."
+            },
+            "AssociatedId": {
+                "required": [
+                    "id",
+                    "type"
+                ],
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of the associated object."
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The type defining the nature of the association."
+                    }
+                },
+                "description": "Represents an associated object identified by its ID and association type."
+            },
+            "NextPage": {
+                "required": [
+                    "after"
+                ],
+                "type": "object",
+                "properties": {
+                    "link": {
+                        "type": "string",
+                        "example": "?after=NTI1Cg%3D%3D",
+                        "description": "The relative URL link to the next page of results."
+                    },
+                    "after": {
+                        "type": "string",
+                        "example": "NTI1Cg%3D%3D",
+                        "description": "The cursor token used to fetch the next page of results."
+                    }
+                },
+                "example": {
+                    "after": "NTI1Cg%3D%3D",
+                    "link": "?after=NTI1Cg%3D%3D"
+                },
+                "description": "Pagination cursor details for retrieving the next page of results."
+            },
+            "SimplePublicObjectInputForCreate": {
+                "type": "object",
+                "properties": {
+                    "associations": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/PublicAssociationsForObject"
+                        },
+                        "description": "List of associations linking this product to other CRM objects."
+                    },
+                    "objectWriteTraceId": {
+                        "type": "string",
+                        "description": "Optional trace identifier for tracking the write operation."
+                    },
+                    "properties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "type": "string"
+                        },
+                        "example": {
+                            "name": "Coffee",
+                            "price": "10.00",
+                            "hs_sku": "121212"
+                        },
+                        "description": "Key-value pairs of product property names and their string values."
+                    }
+                },
+                "example": {
+                    "properties": {
+                        "name": "Implementation Service ",
+                        "price": "6000.00",
+                        "hs_sku": "191902",
+                        "description": "Onboarding service for data product",
+                        "hs_cost_of_goods_sold": "600.00",
+                        "hs_recurring_billing_period": "12"
+                    },
+                    "associations": [
+                        {
+                            "to": {
+                                "id": "101"
+                            },
+                            "types": [
+                                {
+                                    "associationCategory": "HUBSPOT_DEFINED",
+                                    "associationTypeId": 2
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "description": "Input schema for creating a new product, including properties and associations."
+            }
+        },
+        "responses": {
+            "Error": {
+                "description": "An error occurred.",
+                "content": {
+                    "*/*": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Error"
+                        }
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "oauth2_legacy": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.goals.read": "Read goals",
+                            "tickets": "Read and write tickets",
+                            "crm.objects.custom.read": "View custom object records",
+                            "e-commerce": "e-commerce",
+                            "crm.objects.custom.write": "Change custom object records",
+                            "media_bridge.read": "Read media and media events"
+                        }
+                    }
+                }
+            },
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "authorizationCode": {
+                        "authorizationUrl": "https://app.hubspot.com/oauth/authorize",
+                        "tokenUrl": "https://api.hubapi.com/oauth/v1/token",
+                        "scopes": {
+                            "crm.objects.companies.write": " ",
+                            "crm.objects.contacts.write": " ",
+                            "crm.objects.users.write": "Write User CRM objects",
+                            "crm.objects.commercepayments.read": "Read the COMMERCE_PAYMENT object.",
+                            "crm.objects.leads.write": "Modify lead objects",
+                            "crm.objects.subscriptions.read": "Read Commerce Subscriptions",
+                            "crm.objects.carts.read": "Read carts",
+                            "crm.objects.orders.write": "Write orders",
+                            "crm.objects.quotes.read": "Quotes",
+                            "crm.objects.services.read": "Read services",
+                            "crm.objects.orders.read": "Read Orders",
+                            "crm.objects.contacts.read": " ",
+                            "crm.objects.listings.read": "Read listings",
+                            "crm.objects.carts.write": "Write cart",
+                            "crm.objects.courses.write": "Write courses",
+                            "crm.objects.quotes.write": "Quotes",
+                            "crm.objects.users.read": "Read User CRM objects",
+                            "crm.objects.companies.read": " ",
+                            "crm.objects.appointments.read": "Read appointments",
+                            "crm.objects.partner-clients.write": "Modify Partner Client CRM objects",
+                            "crm.objects.leads.read": "Read lead objects",
+                            "crm.objects.appointments.write": "Write appointments",
+                            "crm.objects.services.write": "Write services",
+                            "crm.objects.line_items.read": "Line Items",
+                            "crm.objects.courses.read": "Read courses",
+                            "crm.objects.deals.read": " ",
+                            "crm.objects.invoices.read": "Read invoices objects",
+                            "crm.objects.partner-clients.read": "View Partner Client CRM objects",
+                            "crm.objects.deals.write": " ",
+                            "crm.objects.line_items.write": "Line Items",
+                            "crm.objects.listings.write": "Write listings"
+                        }
+                    }
+                }
+            },
+            "private_apps_legacy": {
+                "type": "apiKey",
+                "name": "private-app-legacy",
+                "in": "header",
+                "x-ballerina-name": "privateAppLegacy"
+            },
+            "private_apps": {
+                "type": "apiKey",
+                "name": "private-app",
+                "in": "header",
+                "x-ballerina-name": "privateApp"
+            }
+        }
+    },
+    "x-hubspot-available-client-libraries": [
+        "PHP",
+        "Node",
+        "Ruby",
+        "Python"
+    ],
+    "x-hubspot-product-tier-requirements": {
+        "marketing": "FREE",
+        "sales": "FREE",
+        "service": "FREE",
+        "cms": "FREE"
+    },
+    "x-hubspot-documentation-banner": "NONE"
+}

--- a/docs/spec/flattened_openapi.json
+++ b/docs/spec/flattened_openapi.json
@@ -1,0 +1,1676 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "Products",
+    "description" : "",
+    "version" : "v3",
+    "x-hubspot-product-tier-requirements" : {
+      "marketing" : "FREE",
+      "sales" : "FREE",
+      "service" : "FREE",
+      "cms" : "FREE"
+    },
+    "x-hubspot-documentation-banner" : "NONE",
+    "x-hubspot-api-use-case" : "To prepare for an upcoming product launch, use the products API to create a set of products to represent your new offerings. Sales reps can then use these products when creating payment links, invoices, and more.",
+    "x-hubspot-related-documentation" : [ {
+      "name" : "Products Guide",
+      "url" : "https://developers.hubspot.com/beta-docs/guides/api/crm/objects/products"
+    } ],
+    "x-hubspot-introduction" : "Use the products API to create and manage your product library, which is the collection of goods and services that your company offers. Products in your product library can be used as line items when creating deals, payment links, invoices, and quotes."
+  },
+  "servers" : [ {
+    "url" : "https://api.hubapi.com/crm/v3/objects/products"
+  } ],
+  "tags" : [ {
+    "name" : "Batch"
+  }, {
+    "name" : "Basic"
+  }, {
+    "name" : "Search"
+  } ],
+  "paths" : {
+    "/batch/read" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Read a batch of products by internal ID, or unique property values",
+        "operationId" : "post-/batch/read_read",
+        "parameters" : [ {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchReadInputSimplePublicObjectId"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/{productId}" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Read",
+        "description" : "Read an Object identified by `{productId}`. `{productId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param.  Control what is returned via the `properties` query param.",
+        "operationId" : "get-/{productId}_getById",
+        "parameters" : [ {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "properties",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "propertiesWithHistory",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "associations",
+          "in" : "query",
+          "description" : "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        }, {
+          "name" : "idProperty",
+          "in" : "query",
+          "description" : "The name of a property whose values are unique for this object",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObjectWithAssociations"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      },
+      "delete" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Archive",
+        "description" : "Move an Object identified by `{productId}` to the recycling bin.",
+        "operationId" : "delete-/{productId}_archive",
+        "parameters" : [ {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      },
+      "patch" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Update",
+        "description" : "Perform a partial update of an Object identified by `{productId}`. `{productId}` refers to the internal object ID by default, or optionally any unique property value as specified by the `idProperty` query param. Provided property values will be overwritten. Read-only and non-existent properties will result in an error. Properties values can be cleared by passing an empty string.",
+        "operationId" : "patch-/{productId}_update",
+        "parameters" : [ {
+          "name" : "productId",
+          "in" : "path",
+          "required" : true,
+          "style" : "simple",
+          "explode" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "idProperty",
+          "in" : "query",
+          "description" : "The name of a property whose values are unique for this object",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SimplePublicObjectInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/batch/archive" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Archive a batch of products by ID",
+        "operationId" : "post-/batch/archive_archive",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectId"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "204" : {
+            "description" : "No content",
+            "content" : { }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/batch/create" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create a batch of products",
+        "operationId" : "post-/batch/create_create",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectInputForCreate"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/batch/update" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Update a batch of products by internal ID, or unique property values",
+        "operationId" : "post-/batch/update_update",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectBatchInput"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/" : {
+      "get" : {
+        "tags" : [ "Basic" ],
+        "summary" : "List",
+        "description" : "Read a page of products. Control what is returned via the `properties` query param.",
+        "operationId" : "get-_getPage",
+        "parameters" : [ {
+          "name" : "limit",
+          "in" : "query",
+          "description" : "The maximum number of results to display per page",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "integer",
+            "format" : "int32",
+            "default" : 10
+          }
+        }, {
+          "name" : "after",
+          "in" : "query",
+          "description" : "The paging cursor token of the last successfully read resource will be returned as the `paging.next.after` JSON property of a paged response containing more results",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "properties",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned in the response. If any of the specified properties are not present on the requested object(s), they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "propertiesWithHistory",
+          "in" : "query",
+          "description" : "A comma separated list of the properties to be returned along with their history of previous values. If any of the specified properties are not present on the requested object(s), they will be ignored. Usage of this parameter will reduce the maximum number of objects that can be read by a single request",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "associations",
+          "in" : "query",
+          "description" : "A comma separated list of object types to retrieve associated IDs for. If any of the specified associations do not exist, they will be ignored",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }, {
+          "name" : "archived",
+          "in" : "query",
+          "description" : "Whether to return only results that have been archived",
+          "required" : false,
+          "style" : "form",
+          "explode" : true,
+          "schema" : {
+            "type" : "boolean",
+            "default" : false
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseSimplePublicObjectWithAssociationsForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      },
+      "post" : {
+        "tags" : [ "Basic" ],
+        "summary" : "Create",
+        "description" : "Create a product with the given properties and return a copy of the object, including the ID. Documentation and examples for creating standard products is provided.",
+        "operationId" : "post-_create",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SimplePublicObjectInputForCreate"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "201" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/SimplePublicObject"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/batch/upsert" : {
+      "post" : {
+        "tags" : [ "Batch" ],
+        "summary" : "Create or update a batch of products by unique property values",
+        "description" : "Create or update records identified by a unique property value as specified by the `idProperty` query param. `idProperty` query param refers to a property whose values are unique for the object.",
+        "operationId" : "post-/batch/upsert_upsert",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/BatchInputSimplePublicObjectBatchInputUpsert"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicUpsertObject"
+                }
+              }
+            }
+          },
+          "207" : {
+            "description" : "multiple statuses",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/BatchResponseSimplePublicUpsertObjectWithErrors"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ]
+      }
+    },
+    "/search" : {
+      "post" : {
+        "tags" : [ "Search" ],
+        "operationId" : "post-/search_doSearch",
+        "parameters" : [ ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/PublicObjectSearchRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "successful operation",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/CollectionResponseWithTotalSimplePublicObjectForwardPaging"
+                }
+              }
+            }
+          },
+          "default" : {
+            "$ref" : "#/components/responses/Error"
+          }
+        },
+        "security" : [ {
+          "oauth2_legacy" : [ "e-commerce" ]
+        }, {
+          "private_apps_legacy" : [ "e-commerce" ]
+        } ],
+        "x-hubspot-rate-limit-exemptions" : [ "ten-secondly" ]
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "StandardError" : {
+        "required" : [ "category", "context", "errors", "links", "message", "status" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "object",
+            "properties" : { }
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            }
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "category" : {
+            "type" : "string"
+          },
+          "message" : {
+            "type" : "string"
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          },
+          "status" : {
+            "type" : "string"
+          }
+        }
+      },
+      "CollectionResponseAssociatedId" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/Paging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AssociatedId"
+            }
+          }
+        }
+      },
+      "PublicAssociationsForObject" : {
+        "required" : [ "to", "types" ],
+        "type" : "object",
+        "properties" : {
+          "types" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/AssociationSpec"
+            }
+          },
+          "to" : {
+            "$ref" : "#/components/schemas/PublicObjectId"
+          }
+        }
+      },
+      "BatchResponseSimplePublicObject" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "FilterGroup" : {
+        "required" : [ "filters" ],
+        "type" : "object",
+        "properties" : {
+          "filters" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/Filter"
+            }
+          }
+        }
+      },
+      "ErrorDetail" : {
+        "required" : [ "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "code" : {
+            "type" : "string",
+            "description" : "The status code associated with the error detail"
+          },
+          "in" : {
+            "type" : "string",
+            "description" : "The name of the field or parameter in which the error was found"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ]
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate"
+          }
+        }
+      },
+      "ForwardPaging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          }
+        }
+      },
+      "SimplePublicObjectId" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "BatchResponseSimplePublicUpsertObjectWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicUpsertObject"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchReadInputSimplePublicObjectId" : {
+        "required" : [ "inputs", "properties", "propertiesWithHistory" ],
+        "type" : "object",
+        "properties" : {
+          "propertiesWithHistory" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "idProperty" : {
+            "type" : "string",
+            "description" : "The name of a property whose values are unique for this object"
+          },
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectId"
+            }
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          }
+        }
+      },
+      "BatchResponseSimplePublicUpsertObject" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicUpsertObject"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectId" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectId"
+            }
+          }
+        }
+      },
+      "ValueWithTimestamp" : {
+        "required" : [ "sourceType", "timestamp", "value" ],
+        "type" : "object",
+        "properties" : {
+          "sourceId" : {
+            "type" : "string"
+          },
+          "sourceType" : {
+            "type" : "string"
+          },
+          "sourceLabel" : {
+            "type" : "string"
+          },
+          "updatedByUserId" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "timestamp" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectBatchInputUpsert" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectBatchInputUpsert"
+            }
+          }
+        }
+      },
+      "CollectionResponseWithTotalSimplePublicObjectForwardPaging" : {
+        "required" : [ "results", "total" ],
+        "type" : "object",
+        "properties" : {
+          "total" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          }
+        }
+      },
+      "SimplePublicObject" : {
+        "required" : [ "createdAt", "id", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "archived" : {
+            "type" : "boolean",
+            "example" : false
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string",
+            "example" : "512"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "nullable" : true
+            },
+            "example" : {
+              "property_date" : "1572480000000",
+              "property_radio" : "option_1",
+              "property_number" : "17",
+              "property_string" : "value",
+              "property_checkbox" : "false",
+              "property_dropdown" : "choice_b",
+              "property_multiple_checkboxes" : "chocolate;strawberry"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        },
+        "example" : {
+          "id" : "512",
+          "properties" : {
+            "createdate" : "2019-10-30T03:30:17.883Z",
+            "description" : "Onboarding service for data product",
+            "hs_cost_of_goods_sold" : "600.00",
+            "hs_lastmodifieddate" : "2019-12-07T16:50:06.678Z",
+            "hs_recurring_billing_period" : "12",
+            "hs_sku" : "191902",
+            "name" : "Implementation Service ",
+            "price" : "6000.00"
+          },
+          "createdAt" : "2019-10-30T03:30:17.883Z",
+          "updatedAt" : "2019-12-07T16:50:06.678Z",
+          "archived" : false
+        }
+      },
+      "PublicObjectId" : {
+        "required" : [ "id" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          }
+        }
+      },
+      "Paging" : {
+        "type" : "object",
+        "properties" : {
+          "next" : {
+            "$ref" : "#/components/schemas/NextPage"
+          },
+          "prev" : {
+            "$ref" : "#/components/schemas/PreviousPage"
+          }
+        }
+      },
+      "PublicObjectSearchRequest" : {
+        "type" : "object",
+        "properties" : {
+          "query" : {
+            "type" : "string"
+          },
+          "limit" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "after" : {
+            "type" : "string"
+          },
+          "sorts" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "properties" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "filterGroups" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/FilterGroup"
+            }
+          }
+        }
+      },
+      "Error" : {
+        "required" : [ "category", "correlationId", "message" ],
+        "type" : "object",
+        "properties" : {
+          "subCategory" : {
+            "type" : "string",
+            "description" : "A specific category that contains more specific detail about the error"
+          },
+          "context" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "type" : "string"
+              }
+            },
+            "description" : "Context about the error condition",
+            "example" : {
+              "missingScopes" : [ "scope1", "scope2" ],
+              "invalidPropertyName" : [ "propertyValue" ]
+            }
+          },
+          "correlationId" : {
+            "type" : "string",
+            "description" : "A unique identifier for the request. Include this value with any error reports or support tickets",
+            "format" : "uuid",
+            "example" : "aeb5f871-7f07-4993-9211-075dc63e7cbf"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "description" : "A map of link names to associated URIs containing documentation about the error or recommended remediation steps",
+            "example" : {
+              "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+            }
+          },
+          "message" : {
+            "type" : "string",
+            "description" : "A human readable message describing the error along with remediation steps where appropriate",
+            "example" : "Invalid input (details will vary based on the error)"
+          },
+          "category" : {
+            "type" : "string",
+            "description" : "The error category",
+            "example" : "VALIDATION_ERROR"
+          },
+          "errors" : {
+            "type" : "array",
+            "description" : "further information about the error",
+            "items" : {
+              "$ref" : "#/components/schemas/ErrorDetail"
+            }
+          }
+        },
+        "example" : {
+          "message" : "Invalid input (details will vary based on the error)",
+          "correlationId" : "aeb5f871-7f07-4993-9211-075dc63e7cbf",
+          "category" : "VALIDATION_ERROR",
+          "links" : {
+            "knowledge-base" : "https://www.hubspot.com/products/service/knowledge-base"
+          }
+        }
+      },
+      "SimplePublicObjectBatchInputUpsert" : {
+        "required" : [ "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "idProperty" : {
+            "type" : "string",
+            "description" : "The name of a property whose values are unique for this object"
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "name" : "Coffee",
+              "price" : "10.00",
+              "hs_sku" : "121212"
+            }
+          }
+        }
+      },
+      "BatchResponseSimplePublicObjectWithErrors" : {
+        "required" : [ "completedAt", "results", "startedAt", "status" ],
+        "type" : "object",
+        "properties" : {
+          "completedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "numErrors" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "requestedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "startedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "links" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObject"
+            }
+          },
+          "errors" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/StandardError"
+            }
+          },
+          "status" : {
+            "type" : "string",
+            "enum" : [ "PENDING", "PROCESSING", "CANCELED", "COMPLETE" ]
+          }
+        }
+      },
+      "SimplePublicObjectInput" : {
+        "required" : [ "properties" ],
+        "type" : "object",
+        "properties" : {
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "property_date" : "1572480000000",
+              "property_radio" : "option_1",
+              "property_number" : "17",
+              "property_string" : "value",
+              "property_checkbox" : "false",
+              "property_dropdown" : "choice_b",
+              "property_multiple_checkboxes" : "chocolate;strawberry"
+            }
+          }
+        },
+        "example" : {
+          "properties" : {
+            "name" : "Implementation Service ",
+            "price" : "6000.00",
+            "hs_sku" : "191902",
+            "description" : "Onboarding service for data product",
+            "hs_cost_of_goods_sold" : "600.00",
+            "hs_recurring_billing_period" : "12"
+          },
+          "associations" : [ {
+            "to" : {
+              "id" : "101"
+            },
+            "types" : [ {
+              "associationCategory" : "HUBSPOT_DEFINED",
+              "associationTypeId" : 2
+            } ]
+          } ]
+        }
+      },
+      "CollectionResponseSimplePublicObjectWithAssociationsForwardPaging" : {
+        "required" : [ "results" ],
+        "type" : "object",
+        "properties" : {
+          "paging" : {
+            "$ref" : "#/components/schemas/ForwardPaging"
+          },
+          "results" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectWithAssociations"
+            }
+          }
+        }
+      },
+      "AssociationSpec" : {
+        "required" : [ "associationCategory", "associationTypeId" ],
+        "type" : "object",
+        "properties" : {
+          "associationCategory" : {
+            "type" : "string",
+            "enum" : [ "HUBSPOT_DEFINED", "USER_DEFINED", "INTEGRATOR_DEFINED" ]
+          },
+          "associationTypeId" : {
+            "type" : "integer",
+            "format" : "int32"
+          }
+        }
+      },
+      "SimplePublicObjectWithAssociations" : {
+        "required" : [ "createdAt", "id", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "$ref" : "#/components/schemas/CollectionResponseAssociatedId"
+            }
+          },
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "archived" : {
+            "type" : "boolean"
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string",
+              "nullable" : true
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        },
+        "example" : {
+          "properties" : {
+            "createdate" : "2019-10-30T03:30:17.883Z",
+            "description" : "Onboarding service for data product",
+            "hs_cost_of_goods_sold" : "600.00",
+            "hs_lastmodifieddate" : "2019-12-07T16:50:06.678Z",
+            "hs_recurring_billing_period" : "12",
+            "hs_sku" : "191902",
+            "name" : "Implementation Service ",
+            "price" : "6000.00"
+          }
+        }
+      },
+      "Filter" : {
+        "required" : [ "operator", "propertyName" ],
+        "type" : "object",
+        "properties" : {
+          "highValue" : {
+            "type" : "string"
+          },
+          "propertyName" : {
+            "type" : "string"
+          },
+          "values" : {
+            "type" : "array",
+            "items" : {
+              "type" : "string"
+            }
+          },
+          "value" : {
+            "type" : "string"
+          },
+          "operator" : {
+            "type" : "string",
+            "description" : "null",
+            "enum" : [ "EQ", "NEQ", "LT", "LTE", "GT", "GTE", "BETWEEN", "IN", "NOT_IN", "HAS_PROPERTY", "NOT_HAS_PROPERTY", "CONTAINS_TOKEN", "NOT_CONTAINS_TOKEN" ]
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectBatchInput" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectBatchInput"
+            }
+          }
+        }
+      },
+      "BatchInputSimplePublicObjectInputForCreate" : {
+        "required" : [ "inputs" ],
+        "type" : "object",
+        "properties" : {
+          "inputs" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/SimplePublicObjectInputForCreate"
+            }
+          }
+        }
+      },
+      "PreviousPage" : {
+        "required" : [ "before" ],
+        "type" : "object",
+        "properties" : {
+          "before" : {
+            "type" : "string"
+          },
+          "link" : {
+            "type" : "string"
+          }
+        }
+      },
+      "SimplePublicUpsertObject" : {
+        "required" : [ "createdAt", "id", "new", "properties", "updatedAt" ],
+        "type" : "object",
+        "properties" : {
+          "createdAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "archived" : {
+            "type" : "boolean"
+          },
+          "archivedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          },
+          "new" : {
+            "type" : "boolean"
+          },
+          "propertiesWithHistory" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "array",
+              "items" : {
+                "$ref" : "#/components/schemas/ValueWithTimestamp"
+              }
+            }
+          },
+          "id" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          },
+          "updatedAt" : {
+            "type" : "string",
+            "format" : "date-time"
+          }
+        }
+      },
+      "SimplePublicObjectBatchInput" : {
+        "required" : [ "id", "properties" ],
+        "type" : "object",
+        "properties" : {
+          "idProperty" : {
+            "type" : "string",
+            "description" : "The name of a property whose values are unique for this object",
+            "example" : "my_unique_property_name"
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "id" : {
+            "type" : "string",
+            "description" : "The id to be updated. This can be the object id, or the unique property value of the idProperty property"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "name" : "Coffee",
+              "price" : "10.00",
+              "hs_sku" : "121212"
+            }
+          }
+        },
+        "example" : {
+          "id" : "1",
+          "properties" : {
+            "name" : "Implementation Service ",
+            "price" : "6000.00",
+            "hs_sku" : "191902",
+            "description" : "Onboarding service for data product",
+            "hs_cost_of_goods_sold" : "600.00",
+            "hs_recurring_billing_period" : "12"
+          }
+        }
+      },
+      "AssociatedId" : {
+        "required" : [ "id", "type" ],
+        "type" : "object",
+        "properties" : {
+          "id" : {
+            "type" : "string"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        }
+      },
+      "NextPage" : {
+        "required" : [ "after" ],
+        "type" : "object",
+        "properties" : {
+          "link" : {
+            "type" : "string",
+            "example" : "?after=NTI1Cg%3D%3D"
+          },
+          "after" : {
+            "type" : "string",
+            "example" : "NTI1Cg%3D%3D"
+          }
+        },
+        "example" : {
+          "after" : "NTI1Cg%3D%3D",
+          "link" : "?after=NTI1Cg%3D%3D"
+        }
+      },
+      "SimplePublicObjectInputForCreate" : {
+        "type" : "object",
+        "properties" : {
+          "associations" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/PublicAssociationsForObject"
+            }
+          },
+          "objectWriteTraceId" : {
+            "type" : "string"
+          },
+          "properties" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            },
+            "example" : {
+              "name" : "Coffee",
+              "price" : "10.00",
+              "hs_sku" : "121212"
+            }
+          }
+        },
+        "example" : {
+          "properties" : {
+            "name" : "Implementation Service ",
+            "price" : "6000.00",
+            "hs_sku" : "191902",
+            "description" : "Onboarding service for data product",
+            "hs_cost_of_goods_sold" : "600.00",
+            "hs_recurring_billing_period" : "12"
+          },
+          "associations" : [ {
+            "to" : {
+              "id" : "101"
+            },
+            "types" : [ {
+              "associationCategory" : "HUBSPOT_DEFINED",
+              "associationTypeId" : 2
+            } ]
+          } ]
+        }
+      }
+    },
+    "responses" : {
+      "Error" : {
+        "description" : "An error occurred.",
+        "content" : {
+          "*/*" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes" : {
+      "oauth2_legacy" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.goals.read" : "Read goals",
+              "tickets" : "Read and write tickets",
+              "crm.objects.custom.read" : "View custom object records",
+              "e-commerce" : "e-commerce",
+              "crm.objects.custom.write" : "Change custom object records",
+              "media_bridge.read" : "Read media and media events"
+            }
+          }
+        }
+      },
+      "oauth2" : {
+        "type" : "oauth2",
+        "flows" : {
+          "authorizationCode" : {
+            "authorizationUrl" : "https://app.hubspot.com/oauth/authorize",
+            "tokenUrl" : "https://api.hubapi.com/oauth/v1/token",
+            "scopes" : {
+              "crm.objects.companies.write" : " ",
+              "crm.objects.contacts.write" : " ",
+              "crm.objects.users.write" : "Write User CRM objects",
+              "crm.objects.commercepayments.read" : "Read the COMMERCE_PAYMENT object.",
+              "crm.objects.leads.write" : "Modify lead objects",
+              "crm.objects.subscriptions.read" : "Read Commerce Subscriptions",
+              "crm.objects.carts.read" : "Read carts",
+              "crm.objects.orders.write" : "Write orders",
+              "crm.objects.quotes.read" : "Quotes",
+              "crm.objects.services.read" : "Read services",
+              "crm.objects.orders.read" : "Read Orders",
+              "crm.objects.contacts.read" : " ",
+              "crm.objects.listings.read" : "Read listings",
+              "crm.objects.carts.write" : "Write cart",
+              "crm.objects.courses.write" : "Write courses",
+              "crm.objects.quotes.write" : "Quotes",
+              "crm.objects.users.read" : "Read User CRM objects",
+              "crm.objects.companies.read" : " ",
+              "crm.objects.appointments.read" : "Read appointments",
+              "crm.objects.partner-clients.write" : "Modify Partner Client CRM objects",
+              "crm.objects.leads.read" : "Read lead objects",
+              "crm.objects.appointments.write" : "Write appointments",
+              "crm.objects.services.write" : "Write services",
+              "crm.objects.line_items.read" : "Line Items",
+              "crm.objects.courses.read" : "Read courses",
+              "crm.objects.deals.read" : " ",
+              "crm.objects.invoices.read" : "Read invoices objects",
+              "crm.objects.partner-clients.read" : "View Partner Client CRM objects",
+              "crm.objects.deals.write" : " ",
+              "crm.objects.line_items.write" : "Line Items",
+              "crm.objects.listings.write" : "Write listings"
+            }
+          }
+        }
+      },
+      "private_apps_legacy" : {
+        "type" : "apiKey",
+        "name" : "private-app-legacy",
+        "in" : "header",
+        "x-ballerina-name" : "privateAppLegacy"
+      },
+      "private_apps" : {
+        "type" : "apiKey",
+        "name" : "private-app",
+        "in" : "header",
+        "x-ballerina-name" : "privateApp"
+      }
+    }
+  },
+  "x-hubspot-available-client-libraries" : [ "PHP", "Node", "Ruby", "Python" ],
+  "x-hubspot-product-tier-requirements" : {
+    "marketing" : "FREE",
+    "sales" : "FREE",
+    "service" : "FREE",
+    "cms" : "FREE"
+  },
+  "x-hubspot-documentation-banner" : "NONE"
+}

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_: @DinithiLiyanage
 _Created_: 03/01/2025
-_Updated_: 09/01/2025
+_Updated_: 2026/06/18 \\
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,5 +1,5 @@
-_Author_: @DinithiLiyanage
-_Created_: 03/01/2025
+_Author_: @DinithiLiyanage \
+_Created_: 03/01/2025 \
 _Updated_: 2026/06/18 \
 _Edition_: Swan Lake
 

--- a/docs/spec/sanitations.md
+++ b/docs/spec/sanitations.md
@@ -1,6 +1,6 @@
 _Author_: @DinithiLiyanage
 _Created_: 03/01/2025
-_Updated_: 2026/06/18 \\
+_Updated_: 2026/06/18 \
 _Edition_: Swan Lake
 
 # Sanitation for OpenAPI specification


### PR DESCRIPTION
Improve operation summaries and add field descriptions

## Purpose

The Ballerina client generator builds doc comments solely from the OpenAPI `summary` field. Previously, only `description` was AI-improved, leaving `summary` fields as terse single words (e.g. "Read", "Archive", "Update") that produced unhelpful doc comments. This PR improves the developer experience by replacing those with concise, meaningful action phrases and adding field-level descriptions to generated types.

Fixes [wso2/product-integrator#1701](https://github.com/wso2/product-integrator/issues/1701)

## Changes

- Replace terse single-word operation summaries in `client.bal` with concise action phrases that accurately describe each operation, e.g. "Read" → "Retrieve a record by ID", "Archive" → "Archive a record by ID", "Update" → "Update a record by ID", "List" → "Retrieve a page of records".

- Condense any overlong summaries to fit the 35-character doc-comment cap.

- Add missing summaries where absent (e.g. search operations).

- Add AI-generated field-level descriptions to `types.bal` to improve generated documentation.

- Refresh `sanitations.md` with updated regeneration timestamp and add `aligned_ballerina_openapi.json` and `flattened_openapi.json` spec artifacts.

## Examples

**Before:**
```ballerina
# Read
resource isolated function get records/[string recordId](...) { }

# Archive
resource isolated function delete records/[string recordId](...) { }

# Update
resource isolated function patch records/[string recordId](...) { }
```

**After:**
```ballerina
# Retrieve a record by ID
resource isolated function get records/[string recordId](...) { }

# Archive a record by ID
resource isolated function delete records/[string recordId](...) { }

# Update a record by ID
resource isolated function patch records/[string recordId](...) { }
```

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
